### PR TITLE
DTO-5025 Add authorized_views input var to main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This module provisions a dataset and a list of tables with associated JSON schem
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access | An array of objects that define dataset access for one or more entities. | `any` | <pre>[<br>  {<br>    "role": "roles/bigquery.dataOwner",<br>    "special_group": "projectOwners"<br>  }<br>]</pre> | no |
+| authorized_views | An array of objects with attributes of dataset_id, project_id, and table_id. | list(object) | empty list | no |
 | dataset\_id | Unique ID for the dataset being provisioned. | `string` | n/a | yes |
 | dataset\_labels | Key value pairs in a map for dataset labels | `map(string)` | `{}` | no |
 | dataset\_name | Friendly name for the dataset being provisioned. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,22 @@ resource "google_bigquery_dataset" "main" {
       special_group  = lookup(access.value, "special_group", null)
     }
   }
+
+  dynamic "access" {
+    for_each = var.authorized_views
+    content {
+      role           = ""
+      group_by_email = ""
+      user_by_email  = ""
+      special_group  = ""
+      domain         = ""
+      view {
+        project_id = access.value.project_id
+        dataset_id = access.value.dataset_id
+        table_id   = access.value.table_id
+      }
+    }
+  }
 }
 
 resource "google_bigquery_table" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,16 @@ variable "access" {
   }]
 }
 
+variable "authorized_views" {
+  description = "An array of views to give authorize for the dataset"
+  type = list(object({
+    dataset_id = string,
+    project_id = string,
+    table_id   = string # this is the view id, but we keep table_id to stay consistent as the resource
+  }))
+  default = []
+}
+
 variable "tables" {
   description = "A list of objects which include table_id, schema, clustering, time_partitioning, range_partitioning, expiration_time and labels."
   default     = []


### PR DESCRIPTION
I did some testing.  In a branch in our data-warehouse-ddl repo, I used the version of this module from this branch.  Changed the usage of this module so that it passes the two locals to the main bigquery_dataset module:
```
module "bigquery_dataset" {
  source                      = "git::https://github.com/cbsi-dto/tf-mod-bq.git?ref=feature/dataset-auth-views-option"
...
  access                      = local.dataset_access
  authorized_views            = local.authorized_views
```
and commented-out using the "authorization" module.

For a dataset where we started with this module (did not do a terraform import), got this plan:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # module.authorization.google_bigquery_dataset_access.access_role["READER_dts-bq-general-information-readers@cbsinteractive.com"] will be destroyed
  - resource "google_bigquery_dataset_access" "access_role" {
      - api_updated_member = false -> null
      - dataset_id         = "static_data_vw" -> null
      - group_by_email     = "dts-bq-general-information-readers@cbsinteractive.com" -> null
      - id                 = "projects/i-dss-dw-prod/datasets/static_data_vw" -> null
      - project            = "i-dss-dw-prod" -> null
      - role               = "READER" -> null
    }

  # module.bigquery_dataset.google_bigquery_dataset.main will be updated in-place
  ~ resource "google_bigquery_dataset" "main" {
        id                              = "projects/i-dss-dw-prod/datasets/static_data_vw"
        # (12 unchanged attributes hidden)

      - access {
          - role          = "OWNER" -> null
          - user_by_email = "dts-bq-admin@i-dss-dw-prod.iam.gserviceaccount.com" -> null
        }
      - access {
          - role          = "OWNER" -> null
          - special_group = "projectOwners" -> null
        }
      - access {
          - role          = "READER" -> null
          - special_group = "projectReaders" -> null
        }
      - access {
          - role          = "WRITER" -> null
          - special_group = "projectWriters" -> null
        }
      - access {
          - group_by_email = "dts-bq-general-information-readers@cbsinteractive.com" -> null
          - role           = "READER" -> null
        }
      + access {
          + group_by_email = "dts-bq-general-information-readers@cbsinteractive.com"
          + role           = "READER"
        }
    }

Plan: 0 to add, 1 to change, 1 to destroy.
```

Which makes sense; it's actually paying attention to the live-service access permissions, and making changes to match what is in our TF definition.  Removing those extra permissions that were auto-deployed before.  Before, the module couldn't see those permissions, because it's not working with the dataset object.  We don't need those projectOwners/Readers/Writers permissions, and dts-bq-admin doesn't need to be granted at the dataset level, because it's granted at the folder/project level.

For a dataset where we did terraform import (i-dss-dw-prod/dim_pt):

```
No changes. Infrastructure is up-to-date.
```

It's no longer doing the hundreds of data access attempts.  It sees all the authorized views defined in the dataset object, and it matches our definition, so it proposes no changes.
