### PR TITLE
Add authorized datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This module provisions a dataset and a list of tables with associated JSON schem
 |------|-------------|------|---------|:--------:|
 | access | An array of objects that define dataset access for one or more entities. | `any` | <pre>[<br>  {<br>    "role": "roles/bigquery.dataOwner",<br>    "special_group": "projectOwners"<br>  }<br>]</pre> | no |
 | authorized_views | An array of objects with attributes of dataset_id, project_id, and table_id. | list(object) | empty list | no |
+| authorized\_datasets | An array of datasets to be authorized on the dataset | <pre>list(object({<br>    dataset_id = string,<br>    project_id = string,<br>  }))</pre> | `[]` | no |
 | dataset\_id | Unique ID for the dataset being provisioned. | `string` | n/a | yes |
 | dataset\_labels | Key value pairs in a map for dataset labels | `map(string)` | `{}` | no |
 | dataset\_name | Friendly name for the dataset being provisioned. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,20 @@ locals {
   external_tables    = { for external_table in var.external_tables : external_table["table_id"] => external_table }
   routines           = { for routine in var.routines : routine["routine_id"] => routine }
 
+  auth_role_keys = [
+    for role in var.access :
+    join("_", compact([
+      role["role"],
+      lookup(role, "domain", null),
+      lookup(role, "group_by_email", null),
+      lookup(role, "user_by_email", null),
+      lookup(role, "special_group", null)
+    ]))
+  ]
+  auth_roles    = zipmap(local.auth_role_keys, var.access)
+  auth_views    = { for view in var.authorized_views : "${view["project_id"]}_${view["dataset_id"]}_${view["table_id"]}" => view }
+  auth_datasets = { for dataset in var.authorized_datasets : "${dataset["project_id"]}_${dataset["dataset_id"]}" => dataset }
+
   iam_to_primitive = {
     "roles/bigquery.dataOwner" : "OWNER"
     "roles/bigquery.dataEditor" : "WRITER"
@@ -46,7 +60,7 @@ resource "google_bigquery_dataset" "main" {
   }
 
   dynamic "access" {
-    for_each = var.access
+    for_each = local.auth_roles
     content {
       # BigQuery API converts IAM to primitive roles in its backend.
       # This causes Terraform to show a diff on every plan that uses IAM equivalent roles.
@@ -61,7 +75,7 @@ resource "google_bigquery_dataset" "main" {
   }
 
   dynamic "access" {
-    for_each = var.authorized_views
+    for_each = local.auth_views
     content {
       role           = ""
       group_by_email = ""
@@ -72,6 +86,24 @@ resource "google_bigquery_dataset" "main" {
         project_id = access.value.project_id
         dataset_id = access.value.dataset_id
         table_id   = access.value.table_id
+      }
+    }
+  }
+
+  dynamic "access" {
+    for_each = local.auth_datasets
+    content {
+      role           = ""
+      group_by_email = ""
+      user_by_email  = ""
+      special_group  = ""
+      domain         = ""
+      dataset {
+        dataset {
+          project_id = access.value.project_id
+          dataset_id = access.value.dataset_id
+        }
+        target_types = ["VIEWS"]
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,15 @@ variable "authorized_views" {
   default = []
 }
 
+variable "authorized_datasets" {
+  description = "An array of datasets to be authorized on the dataset"
+  type = list(object({
+    dataset_id = string,
+    project_id = string,
+  }))
+  default = []
+}
+
 variable "tables" {
   description = "A list of objects which include table_id, schema, clustering, time_partitioning, range_partitioning, expiration_time and labels."
   default     = []


### PR DESCRIPTION
DTO-10579 Add authorized datasets to main module.

I still need to test this with data-warehouse-ddl.

Read the code from the authorization module, and brought it up to main module, with changes to fit into the dataset resource instead of an access resource.

Updated our existing code to use the de-duping that the authorization module does, by making a local map.