### PR TITLE
fix: disable deletion protection for external tables 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -184,7 +184,7 @@ resource "google_bigquery_table" "external_table" {
   labels              = each.value["labels"]
   expiration_time     = each.value["expiration_time"]
   project             = var.project_id
-  deletion_protection = var.deletion_protection
+  deletion_protection = false
 
   external_data_configuration {
     autodetect            = each.value["autodetect"]


### PR DESCRIPTION
Wasn't merged in the google repo so submitting it to our fork 
Ref: terraform-google-modules/terraform-google-bigquery/pull/205


External tables are similar to views. Data from them is [read-only](https://cloud.google.com/bigquery/docs/external-tables#limitations); hence there is no need to protect them since the data won't be deleted.