### PR TITLE
Remove dupe description field from table variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -138,7 +138,6 @@ variable "tables" {
     }),
     expiration_time     = string,
     labels              = map(string),
-    description         = string,
     deletion_protection = optional(bool, true),
   }))
 }


### PR DESCRIPTION
fix dupe description from table variable introduced in #8