### PR TITLE
Add support to row-level access policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,12 @@
  */
 
 locals {
-  tables             = { for table in var.tables : table["table_id"] => table }
-  views              = { for view in var.views : view["view_id"] => view }
-  materialized_views = { for mat_view in var.materialized_views : mat_view["view_id"] => mat_view }
-  external_tables    = { for external_table in var.external_tables : external_table["table_id"] => external_table }
-  routines           = { for routine in var.routines : routine["routine_id"] => routine }
+  tables              = { for table in var.tables : table["table_id"] => table }
+  views               = { for view in var.views : view["view_id"] => view }
+  materialized_views  = { for mat_view in var.materialized_views : mat_view["view_id"] => mat_view }
+  external_tables     = { for external_table in var.external_tables : external_table["table_id"] => external_table }
+  routines            = { for routine in var.routines : routine["routine_id"] => routine }
+  row_access_policies = { for policy in var.row_access_policies : "${policy["table_id"]}_${policy["policy_id"]}" => policy }
 
   auth_role_keys = [
     for role in var.access :
@@ -357,4 +358,18 @@ resource "google_bigquery_routine" "routine" {
   }
 
   return_type = each.value["return_type"]
+}
+
+resource "google_bigquery_row_access_policy" "row_access_policy" {
+  for_each         = local.row_access_policies
+  dataset_id       = google_bigquery_dataset.main.dataset_id
+  policy_id        = each.value["policy_id"]
+  table_id         = each.value["table_id"]
+  filter_predicate = each.value["filter_predicate"]
+  grantees         = each.value["grantees"]
+  project          = var.project_id
+
+  depends_on = [
+    google_bigquery_table.main,
+  ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -94,3 +94,11 @@ output "routine_ids" {
   ]
   description = "Unique IDs for any routine being provisioned"
 }
+
+output "row_access_policy_ids" {
+  value = [
+    for policy in google_bigquery_row_access_policy.row_access_policy :
+    policy.policy_id
+  ]
+  description = "Unique IDs for any row access policies being provisioned"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -254,3 +254,31 @@ variable "routines" {
     })),
   }))
 }
+
+variable "row_access_policies" {
+  description = "A list of objects which include policy_id, table_id, filter_predicate and grantees for row-level security."
+  default     = []
+  type = list(object({
+    policy_id        = string,
+    table_id         = string,
+    filter_predicate = string,
+    grantees         = optional(list(string)),
+  }))
+
+  validation {
+    condition = alltrue([
+      for policy in var.row_access_policies : contains(
+        [for table in var.tables : table.table_id],
+        policy.table_id
+      )
+    ])
+    error_message = "All table_id values in row_access_policies must exist in at least one of the tables. Please ensure that every table referenced in row access policies is defined in the respective resource list."
+  }
+
+  validation {
+    condition = length(var.row_access_policies) == length(distinct([
+      for policy in var.row_access_policies : "${policy.table_id}_${policy.policy_id}"
+    ]))
+    error_message = "Each combination of table_id and policy_id in row_access_policies must be unique."
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -15,12 +15,12 @@
  */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.59, < 6"
+      version = ">= 6.36.0, < 7"
     }
   }
 


### PR DESCRIPTION
- Introduce a new variable for row access policies.
- Add a resource for BigQuery row access policies.
- Update outputs to include row access policy IDs.
- Increase required Terraform version due the variable validations.
- Update Google provider version due the BQ feature.