### PR TITLE
DMS-5504: External table plan alignment (compression, deletion_protection, friendly_name)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -264,19 +264,19 @@ resource "google_bigquery_table" "materialized_view" {
 resource "google_bigquery_table" "external_table" {
   for_each            = local.external_tables
   dataset_id          = google_bigquery_dataset.main.dataset_id
-  friendly_name       = each.key
+  friendly_name       = try(each.value["use_default_friendly_name"], true) ? each.key : try(each.value["friendly_name"], null)
   table_id            = each.key
   description         = each.value["description"]
   labels              = each.value["labels"]
   expiration_time     = each.value["expiration_time"]
   max_staleness       = each.value["max_staleness"]
   project             = var.project_id
-  deletion_protection = false
+  deletion_protection = try(each.value["deletion_protection"], false)
   schema              = each.value["connection_id"] != null && !each.value["autodetect"] ? each.value["schema"] : null
 
   external_data_configuration {
     autodetect            = each.value["autodetect"]
-    compression           = each.value["compression"]
+    compression           = try(each.value["compression"], null)
     ignore_unknown_values = each.value["ignore_unknown_values"]
     max_bad_records       = each.value["max_bad_records"]
     schema                = each.value["connection_id"] == null && !each.value["autodetect"] ? each.value["schema"] : null

--- a/variables.tf
+++ b/variables.tf
@@ -199,7 +199,7 @@ variable "external_tables" {
     table_id              = string,
     description           = optional(string),
     autodetect            = bool,
-    compression           = string,
+    compression           = optional(string),
     ignore_unknown_values = bool,
     max_bad_records       = number,
     schema                = optional(string),
@@ -233,6 +233,10 @@ variable "external_tables" {
     }),
     expiration_time = string,
     labels          = map(string),
+    # When true (default), set friendly_name to table_id — legacy behavior. When false, use friendly_name (may be null).
+    use_default_friendly_name = optional(bool, true),
+    friendly_name             = optional(string),
+    deletion_protection       = optional(bool, false),
   }))
 }
 


### PR DESCRIPTION
## Summary

Reduces Terraform plan drift for **imported** BigQuery external tables when live API state differs from the previous module defaults.

## Changes

- `external_data_configuration.compression`: optional (`null` omits attribute; matches APIs that do not return compression).
- `deletion_protection`: configurable per external table (`optional(bool, false)`); default preserves existing behavior when unset.
- `friendly_name`: optional `use_default_friendly_name` + `friendly_name` so tables with **no** friendly name in GCP can be modeled (null) without forcing `table_id` as display name.

## Base

Branch is based on commit `3f509f7f15c3f9efe217dc9ae3600d78312ee751` (current i4b pin).

## Related

- DMS-5504 / data-warehouse-ddl drift for `x_dim_mapping_program_nad_files_stg`.
- Companion **i4b** PR will pass the new fields from etable JSON and adjust compression defaulting.

*Generated by - synap-ai*