### PR TITLE
DMS-5821: honor var.deletion_protection on BigQuery views

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ resource "google_bigquery_table" "view" {
   table_id            = each.key
   labels              = each.value["labels"]
   project             = var.project_id
-  deletion_protection = false
+  deletion_protection = var.deletion_protection
 
   view {
     query          = each.value["query"]


### PR DESCRIPTION
## Summary

`google_bigquery_table.view` currently hardcodes `deletion_protection = false`. When an existing BigQuery view with deletion protection enabled is imported (the standard i4b flow), Terraform always reports a `deletion_protection = true -> false` change, producing perpetual drift on every plan.

This change makes views honor the module-level `var.deletion_protection` (defaults to `true`), aligning views with how `google_bigquery_table.main` already behaves. The dataset-level `deletion_protection` variable is unchanged.

## Why

Tracked under Jira [DMS-5821](https://paramount.atlassian.net/browse/DMS-5821). Concrete repro: `i4b` plan on an existing dataset (e.g. `i-dss-dw-uat2/unity_plus_vw` in `cbsi-dto/data-warehouse-ddl#8944`) reports `10 to change` for the 10 imported views, all `deletion_protection: true -> false`, even though `dataset.yaml` does not request that change.

## Change

One line in `main.tf`:

```diff
 resource "google_bigquery_table" "view" {
   ...
   project             = var.project_id
-  deletion_protection = false
+  deletion_protection = var.deletion_protection
   ...
 }
```

Note: `materialized_view` and `external_table` still use hardcoded `false` for backward compatibility (separate decision; can be a follow-up).

## Validation

- `terraform fmt` clean.
- For consumers that previously relied on the hardcoded `false`, the new behavior matches the default they likely already pass (`var.deletion_protection` default is `true`); they can opt back in by passing `false` explicitly at the module call site.

## Test plan

- [ ] Merge to `main-cbsi`.
- [ ] Bump pinned ref in `cbsi-dto/i4b` `terraform/main.tf` (`module "bigquery_dataset"` source).
- [ ] Re-run `terraform plan` for `bigquery/i-dss-dw-uat2/unity_plus_vw`; confirm the 10 view `deletion_protection` lines no longer appear.

---
*Generated by - synap-ai* (AI generated)

[DMS-5821]: https://paramount.atlassian.net/browse/DMS-5821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ