### PR TITLE
Fix require_partition_filter dropped for external tables

### DIFF
--- a/examples/multiple_tables/main.tf
+++ b/examples/multiple_tables/main.tf
@@ -118,7 +118,8 @@ module "bigquery" {
       hive_partitioning_options = {
         mode = "AUTO"
         # DO NOT CHANGE - see above source_uris
-        source_uri_prefix = "gs://ci-bq-external-data/hive_partition_example/"
+        source_uri_prefix        = "gs://ci-bq-external-data/hive_partition_example/"
+        require_partition_filter = true
       }
       google_sheets_options = null
     },

--- a/main.tf
+++ b/main.tf
@@ -314,8 +314,9 @@ resource "google_bigquery_table" "external_table" {
     dynamic "hive_partitioning_options" {
       for_each = each.value["hive_partitioning_options"] != null ? [each.value["hive_partitioning_options"]] : []
       content {
-        mode              = hive_partitioning_options.value["mode"]
-        source_uri_prefix = hive_partitioning_options.value["source_uri_prefix"]
+        mode                     = hive_partitioning_options.value["mode"]
+        source_uri_prefix        = hive_partitioning_options.value["source_uri_prefix"]
+        require_partition_filter = hive_partitioning_options.value["require_partition_filter"]
       }
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -230,8 +230,9 @@ variable "external_tables" {
       skip_leading_rows = number,
     }),
     hive_partitioning_options = object({
-      mode              = string,
-      source_uri_prefix = string,
+      mode                     = string,
+      source_uri_prefix        = string,
+      require_partition_filter = optional(bool, false),
     }),
     parquet_options = object({
       enum_as_string        = bool,


### PR DESCRIPTION
## Summary
- `hive_partitioning_options` only forwarded `mode` and `source_uri_prefix` to `google_bigquery_table`, so `require_partition_filter` was silently dropped for external tables (GCP defaulted to unenforced full scans regardless of caller intent).
- Adds `require_partition_filter` (optional, default `false`) to the `external_tables.hive_partitioning_options` object type and forwards it in the dynamic block, mirroring how `time_partitioning` already handles it.
- Updates the `multiple_tables` example's `hive_example` table to set `require_partition_filter = true`.

## Test plan
- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` in module root and in `examples/multiple_tables` — both succeed
- [ ] No existing integration test exercises `hive_partitioning_options`; not covered by the repo's Kitchen/InSpec suite